### PR TITLE
PR patches

### DIFF
--- a/mirdata/datasets/indexes/dagstuhl_choirset_index.json
+++ b/mirdata/datasets/indexes/dagstuhl_choirset_index.json
@@ -41,6 +41,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take01_B2": {
@@ -81,6 +85,10 @@
         "2cfc669e11e8d4a7fa632746844eb138"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -125,6 +133,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take01_B4": {
@@ -165,6 +177,10 @@
         "058472ece6fa42e80492c7789e12f75f"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -209,6 +225,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take02_B1": {
@@ -249,6 +269,10 @@
         "11271d65f552612b7220f68f4a748b0b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -293,6 +317,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take02_B3": {
@@ -333,6 +361,10 @@
         null
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -377,6 +409,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take02_B5": {
@@ -417,6 +453,10 @@
         "6cd8c95d609dba14860754b3dc88d681"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -461,6 +501,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take03_B2": {
@@ -501,6 +545,10 @@
         "56a800e45474c334b5b00ec7de64d9fe"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -545,6 +593,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take03_B4": {
@@ -585,6 +637,10 @@
         "4aeea7809275404bec695de2203636c5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -629,6 +685,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take04_B2": {
@@ -669,6 +729,10 @@
         "5ed397b55bb86a8b5bb9e2911254ba1d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -713,6 +777,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take04_B4": {
@@ -753,6 +821,10 @@
         null
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -797,6 +869,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_Basses_Take05_B3": {
@@ -837,6 +913,10 @@
         "2b7da2bd3d97cebb5d7a6629f905fe79"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -881,6 +961,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_FullChoir_Solo01_B2": {
@@ -921,6 +1005,10 @@
         "4b68a3f68888ad737e2fa57de72a34e1"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -965,6 +1053,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_FullChoir_Solo03_T2": {
@@ -1005,6 +1097,10 @@
         "0b5176f3640181281de55278592a34ad"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -1049,6 +1145,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_FullChoir_Solo05_A2": {
@@ -1089,6 +1189,10 @@
         "cd654b16cf42d738f4c52636272494e8"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -1133,6 +1237,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_FullChoir_Solo07_S1": {
@@ -1175,6 +1283,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_FullChoir_Solo08_S2": {
@@ -1215,6 +1327,10 @@
         "5d3adc5bb5d12f59ec7ebec347f5b832"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -2363,6 +2479,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetA_Overacted_B1": {
@@ -2403,6 +2523,10 @@
         "3ed028c848b8a1dcdab8034c98b318fd"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -2447,6 +2571,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetA_Overacted_T1": {
@@ -2487,6 +2615,10 @@
         "a0ab22fdec1fbf484f7048f5c7745298"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -2531,6 +2663,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetA_Solo02_T1": {
@@ -2571,6 +2707,10 @@
         "0c019dce42926c79961881c5af0377bd"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -2615,6 +2755,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetA_Solo04_S2": {
@@ -2655,6 +2799,10 @@
         "3a20f0fce2c87dd7e877cc8221df3662"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -3803,6 +3951,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetB_Overacted_B2": {
@@ -3843,6 +3995,10 @@
         "00e6055d6cbec566b05f906a28f02d2a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -3887,6 +4043,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetB_Overacted_T2": {
@@ -3927,6 +4087,10 @@
         "e4427371594c6ab8b575f43aba597be9"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -3971,6 +4135,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetB_Solo02_T2": {
@@ -4011,6 +4179,10 @@
         "1d898fb8c75027ff1f14d8b7cbdd36e0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -4055,6 +4227,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_LI_QuartetB_Solo04_S1": {
@@ -4095,6 +4271,10 @@
         "1a9b4ac212486da084797dea52fbc1a1"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5059,6 +5239,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Tuning01_B2": {
@@ -5099,6 +5283,10 @@
         "23bcdc4a4c8b6d2a00032b28199c6051"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5143,6 +5331,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Tuning01_B4": {
@@ -5183,6 +5375,10 @@
         "02c87dc0e24060fc0bc852dec387cd2b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5227,6 +5423,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Tuning02_B1": {
@@ -5267,6 +5467,10 @@
         "4fab446105321b20888a28567f92c8ae"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5311,6 +5515,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Tuning02_B3": {
@@ -5351,6 +5559,10 @@
         "b11316d3b793aea0876d6ee14f26d735"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5395,6 +5607,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Tuning02_B5": {
@@ -5435,6 +5651,10 @@
         "067e8da2f08067e1569a32acd8ce715b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5479,6 +5699,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Unison01_B2": {
@@ -5519,6 +5743,10 @@
         "55f5e61053e389f26ba04d1324148cc6"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5563,6 +5791,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_Basses_Unison01_B4": {
@@ -5603,6 +5835,10 @@
         "7c7cb730fa5d7616bd13007c3f1ded7f"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5647,6 +5883,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown01_A1": {
@@ -5687,6 +5927,10 @@
         "b6590582769fcd9604f6a9afdc3189e4"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5731,6 +5975,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown01_B1": {
@@ -5771,6 +6019,10 @@
         "ccfe4516d821400eff88095465c80120"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5815,6 +6067,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown01_S1": {
@@ -5855,6 +6111,10 @@
         "841611524325feccde43e03e6941f8c0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5899,6 +6159,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown01_T1": {
@@ -5939,6 +6203,10 @@
         "3934b16fefd98fd20b84db34d4450bf3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -5983,6 +6251,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown02_A1": {
@@ -6023,6 +6295,10 @@
         "2215c6025b3afe41fc19f9f042986d24"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6067,6 +6343,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown02_B1": {
@@ -6107,6 +6387,10 @@
         "1b913242fb55bcf826efcabd772e8185"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6151,6 +6435,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown02_S1": {
@@ -6191,6 +6479,10 @@
         "b07f4505275b84c2dadc1015f0646cba"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6235,6 +6527,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown02_T1": {
@@ -6275,6 +6571,10 @@
         "507c69f43940044e71ec01936cc94bb7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6319,6 +6619,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown03_A1": {
@@ -6359,6 +6663,10 @@
         "d62fe5dd4186a1bfc78d52e6fa8b85ae"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6403,6 +6711,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown03_B1": {
@@ -6443,6 +6755,10 @@
         "ef727c9a2ad3a79bb18da7751204a0c0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6487,6 +6803,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown03_S1": {
@@ -6527,6 +6847,10 @@
         "2811210acc8d3dbc631b4ea1fb92c841"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6571,6 +6895,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown03_T1": {
@@ -6611,6 +6939,10 @@
         "e28ef40fd1d720f061a2600f3fcff733"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6655,6 +6987,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown04_A1": {
@@ -6695,6 +7031,10 @@
         "ae135e9514ce43a9837e1951a0a5d437"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6739,6 +7079,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown04_B1": {
@@ -6779,6 +7123,10 @@
         "06a54ec81e81e95b7dba7fb11934e21a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6823,6 +7171,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown04_S1": {
@@ -6863,6 +7215,10 @@
         "bb3ec412481f493acd91b196121965f2"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6907,6 +7263,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown04_T1": {
@@ -6947,6 +7307,10 @@
         "9709f69d100d7fcec14725ded0b78146"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -6991,6 +7355,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown05_A1": {
@@ -7031,6 +7399,10 @@
         "712103d0e9f58021e50ba9c950028f46"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7075,6 +7447,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown05_B1": {
@@ -7115,6 +7491,10 @@
         "7d7987527bd51803cfb43a2c5c2ab8cc"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7159,6 +7539,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown05_S1": {
@@ -7199,6 +7583,10 @@
         "57d379a0224b3057af47f3960c9ae95e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7243,6 +7631,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown05_T1": {
@@ -7283,6 +7675,10 @@
         "b70d0d3c06f37149c13cf09c6884a6d1"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7327,6 +7723,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown06_A1": {
@@ -7367,6 +7767,10 @@
         "4efc1c67dabaf17fd84d032e37aa40bf"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7411,6 +7815,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown06_B1": {
@@ -7451,6 +7859,10 @@
         "ec52467b8aeee028607f8121f624bbaf"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7495,6 +7907,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown06_S1": {
@@ -7535,6 +7951,10 @@
         "7cf5010cd365343204741a375613a1fe"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7579,6 +7999,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown06_T1": {
@@ -7619,6 +8043,10 @@
         "446d0eb6d3c4315b3344d17639e7ca67"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7663,6 +8091,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown07_A1": {
@@ -7703,6 +8135,10 @@
         "682a0cf393b00eb356d9205e09f2d481"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7747,6 +8183,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown07_B1": {
@@ -7787,6 +8227,10 @@
         "f7ea078c23e2c55cdf8dcd388dd744bc"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7831,6 +8275,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown07_S1": {
@@ -7871,6 +8319,10 @@
         "6438e1c9741b3b245e9f8969aa7554f8"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7915,6 +8367,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown07_T1": {
@@ -7955,6 +8411,10 @@
         "4266e50641c5e7fac92046b3156f2c44"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -7999,6 +8459,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown08_A1": {
@@ -8039,6 +8503,10 @@
         "961c51aee6e44ea1fb6930b2707dd4db"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8083,6 +8551,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown08_B1": {
@@ -8123,6 +8595,10 @@
         "acabe197c56ac6eefd006afb09baf8f6"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8167,6 +8643,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown08_S1": {
@@ -8207,6 +8687,10 @@
         "30a6cb92ccdf628fc029a82147ffb746"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8251,6 +8735,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown08_T1": {
@@ -8291,6 +8779,10 @@
         "d9b74e1d17eccdd8aba0e18b6e627abf"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8335,6 +8827,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown09_A1": {
@@ -8375,6 +8871,10 @@
         "bcb3793a348c008f1ba7bd4d653a1b0e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8419,6 +8919,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown09_B1": {
@@ -8459,6 +8963,10 @@
         "c61cf1f27ac30685c2005941fa7e6d68"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8503,6 +9011,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown09_S1": {
@@ -8543,6 +9055,10 @@
         "90c2f84b87c2517905eafc8d396c2430"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8587,6 +9103,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown09_T1": {
@@ -8627,6 +9147,10 @@
         "62b7ba6b0014022b3015bec6305696e4"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8671,6 +9195,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown10_A1": {
@@ -8711,6 +9239,10 @@
         "fcf202775dd0d4c7ab6ee7e9b2c6edda"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8755,6 +9287,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown10_B1": {
@@ -8795,6 +9331,10 @@
         "8836145a8e10e4634706932a463ba780"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8839,6 +9379,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown10_S1": {
@@ -8879,6 +9423,10 @@
         "f0c2adf46e95e5187f95e144883bbe33"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -8923,6 +9471,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown10_T1": {
@@ -8963,6 +9515,10 @@
         "5551e726488fbdd9433aa27996bd0cae"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9007,6 +9563,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown11_A1": {
@@ -9047,6 +9607,10 @@
         "e181f017fe1ab692555f7b4c0e1bef4a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9091,6 +9655,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown11_B1": {
@@ -9131,6 +9699,10 @@
         "4434a3f02c438c2b90b8f250ea654a0c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9175,6 +9747,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown11_S1": {
@@ -9215,6 +9791,10 @@
         "024a0f70dedc4bb23b50ee5d49649d8c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9259,6 +9839,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown11_T1": {
@@ -9299,6 +9883,10 @@
         "fb36f12aa6fdc3a5666d1901cea54ed7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9343,6 +9931,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown12_A1": {
@@ -9383,6 +9975,10 @@
         "8dfadc081842977bbc061401478317e0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9427,6 +10023,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown12_B1": {
@@ -9467,6 +10067,10 @@
         "72f0abf397be9846d52afaef95db23fa"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9511,6 +10115,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown12_S1": {
@@ -9551,6 +10159,10 @@
         "12876d125e22091422a60979e44ddd0c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9595,6 +10207,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown12_T1": {
@@ -9635,6 +10251,10 @@
         "139d81588276a44e63be9a5103dd24d7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9679,6 +10299,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown13_A1": {
@@ -9719,6 +10343,10 @@
         "ea1e586a4ad54179df18545d2710a27e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9763,6 +10391,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown13_B1": {
@@ -9803,6 +10435,10 @@
         "cd0c59a3752fa6622cc7ed9577fd9966"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9847,6 +10483,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown13_S1": {
@@ -9887,6 +10527,10 @@
         "ef9891042b1c50cd0b2af76a1124df22"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -9931,6 +10575,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown13_T1": {
@@ -9971,6 +10619,10 @@
         "a7a87a23da1c50b88e6708cf91ef0a9c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10015,6 +10667,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown14_A1": {
@@ -10055,6 +10711,10 @@
         "d5df39e2663dadd47448926832f6d172"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10099,6 +10759,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown14_B1": {
@@ -10139,6 +10803,10 @@
         "3aceedaf953b6ebb6bb71ea479b9c213"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10183,6 +10851,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown14_S1": {
@@ -10223,6 +10895,10 @@
         "c718985974229d635677765a483915ee"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10267,6 +10943,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown14_T1": {
@@ -10307,6 +10987,10 @@
         "d4d40fbab7673649494a9853c14b2e1c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10351,6 +11035,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown15_A1": {
@@ -10391,6 +11079,10 @@
         "702009fdf01e64b6868e4a30577a1afd"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10435,6 +11127,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown15_B1": {
@@ -10475,6 +11171,10 @@
         "c740bf5007e02219d102a7d7f76e7efd"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10519,6 +11219,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown15_S1": {
@@ -10559,6 +11263,10 @@
         "c5f2199f0c612f0819407ecb75f6db01"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10603,6 +11311,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown15_T1": {
@@ -10643,6 +11355,10 @@
         "757e900da756612fee4e60cdf401330d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10687,6 +11403,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown16_A1": {
@@ -10727,6 +11447,10 @@
         "dae7f36414d00dc20d159ef217c36415"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10771,6 +11495,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown16_B1": {
@@ -10811,6 +11539,10 @@
         "50be51570e74512a2c47c6c1bfdb8bad"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10855,6 +11587,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown16_S1": {
@@ -10895,6 +11631,10 @@
         "30b9c445be8a43925f7578f18af51d84"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -10939,6 +11679,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown16_T1": {
@@ -10979,6 +11723,10 @@
         "02b6562e61ff3561118ab08b8d3816f6"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11023,6 +11771,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown17_A1": {
@@ -11063,6 +11815,10 @@
         "f4ce1032cbe7fe34e9630d2b7829552b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11107,6 +11863,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown17_B1": {
@@ -11147,6 +11907,10 @@
         "c39a2a7a2f6ffccce991d1c86407ebc5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11191,6 +11955,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown17_S1": {
@@ -11231,6 +11999,10 @@
         "cf34675539611a1cd675388220de99a0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11275,6 +12047,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown17_T1": {
@@ -11315,6 +12091,10 @@
         "a81a3bfea320fc05e12937591fd8ea49"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11359,6 +12139,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown18_A1": {
@@ -11399,6 +12183,10 @@
         "856066659115deb92680c3fe12c15427"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11443,6 +12231,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown18_B1": {
@@ -11483,6 +12275,10 @@
         "6f40ec39cddf0b4ad945877950ee11a7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11527,6 +12323,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown18_S1": {
@@ -11567,6 +12367,10 @@
         "ba3c61f920ab1a6179e8c4aa4195b5ad"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11611,6 +12415,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown18_T1": {
@@ -11651,6 +12459,10 @@
         "632447331eac2a994c870dce01c029a0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11695,6 +12507,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown19_A1": {
@@ -11735,6 +12551,10 @@
         "ef9dae73f39d0aa3c0fa8c8cb9911420"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11779,6 +12599,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown19_B1": {
@@ -11819,6 +12643,10 @@
         "2eb2d3993f0e5cad3bd811c9f070f3eb"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11863,6 +12691,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown19_S1": {
@@ -11903,6 +12735,10 @@
         "cdf7b3785d549b443394391373867cfe"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -11947,6 +12783,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown19_T1": {
@@ -11987,6 +12827,10 @@
         "d8278fbc36d5f4c2c442713263dc17b5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12031,6 +12875,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown20_A1": {
@@ -12071,6 +12919,10 @@
         "b26bcb9e222ef0ec59c9b9e82c5ab976"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12115,6 +12967,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown20_B1": {
@@ -12155,6 +13011,10 @@
         "f88649c4278685beb7d413362e074c5e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12199,6 +13059,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown20_S1": {
@@ -12239,6 +13103,10 @@
         "7846f940dc978c2a05ab86454e41844a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12283,6 +13151,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown20_T1": {
@@ -12323,6 +13195,10 @@
         "230b28d9df20b36e0b381156bf0ecb8e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12367,6 +13243,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown21_A1": {
@@ -12407,6 +13287,10 @@
         "b932b47774dd43ecb8592a8746e8bf92"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12451,6 +13335,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown21_B1": {
@@ -12491,6 +13379,10 @@
         "fe610b53047c40d4643d38bfd472f699"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12535,6 +13427,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown21_S1": {
@@ -12575,6 +13471,10 @@
         "c0a04936173012f34f182cee56fb677a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12619,6 +13519,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown21_T1": {
@@ -12659,6 +13563,10 @@
         "ac0fd3505c360b546134d422ce896de8"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12703,6 +13611,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown22_A1": {
@@ -12743,6 +13655,10 @@
         "c4f07a4006fc5643fc0ce8cfca6b0cdf"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12787,6 +13703,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown22_B1": {
@@ -12827,6 +13747,10 @@
         "8ea3c3a299b4c94f68d00b71f8f5ba9b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12871,6 +13795,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown22_S1": {
@@ -12911,6 +13839,10 @@
         "17cf116c89419d1668e4b32a6f9141a7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -12955,6 +13887,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown22_T1": {
@@ -12995,6 +13931,10 @@
         "e658244a3e1957d291c8f087d034a114"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13039,6 +13979,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown23_A1": {
@@ -13079,6 +14023,10 @@
         "031f3b973838ce4278f5547c85a5a5c7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13123,6 +14071,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown23_B1": {
@@ -13163,6 +14115,10 @@
         "d16d4246759d929327013660365fe5e7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13207,6 +14163,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown23_S1": {
@@ -13247,6 +14207,10 @@
         "6bf7c6dc9b5a0d4029e5566b498dfb95"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13291,6 +14255,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown23_T1": {
@@ -13331,6 +14299,10 @@
         "8ea2ebb5e42b82523afabb6ed7057033"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13375,6 +14347,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown24_A1": {
@@ -13415,6 +14391,10 @@
         "91fc2c34ce239192cc884b5bae8aca3e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13459,6 +14439,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown24_B1": {
@@ -13499,6 +14483,10 @@
         "aa878f9581ac18bf432742dbc4f16041"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13543,6 +14531,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown24_S1": {
@@ -13583,6 +14575,10 @@
         "e17b9ec1362520f3cf7e911e2a299a10"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13627,6 +14623,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDown24_T1": {
@@ -13667,6 +14667,10 @@
         "5749bfbe32eb6e711aff8d4d2aa9f87c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13711,6 +14715,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano01_A1": {
@@ -13751,6 +14759,10 @@
         "2d82b187b3fd2ed78d9a29e4ad410ec3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13795,6 +14807,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano01_B1": {
@@ -13835,6 +14851,10 @@
         "9e67011809f296d7cc6c41f950f955d2"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13879,6 +14899,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano01_S1": {
@@ -13919,6 +14943,10 @@
         "d1f11bb07d38eb4a32f3518906442dc8"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -13963,6 +14991,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano01_T1": {
@@ -14003,6 +15035,10 @@
         "21c5eb3f5a1f2ff91114e019ef6cf8e8"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14047,6 +15083,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano02_A1": {
@@ -14087,6 +15127,10 @@
         "ea979037fb5866be9148767168d8c75d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14131,6 +15175,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano02_B1": {
@@ -14171,6 +15219,10 @@
         "59f7b8f59152143b64526f2db5ae0a11"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14215,6 +15267,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano02_S1": {
@@ -14255,6 +15311,10 @@
         "089bc0315c5a1123119ea4754c2335df"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14299,6 +15359,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano02_T1": {
@@ -14339,6 +15403,10 @@
         "c8b6793f1caaf723c3fe16772fbc07b5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14383,6 +15451,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano03_A1": {
@@ -14423,6 +15495,10 @@
         "ba272b86bd0399518cfd5676eb6134a5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14467,6 +15543,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano03_B1": {
@@ -14507,6 +15587,10 @@
         "8dd17fd7f0dd6fd46eb00eb8ccdc8289"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14551,6 +15635,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano03_S1": {
@@ -14591,6 +15679,10 @@
         "b58c1d42e5fea466124d2ac453dbcb23"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14635,6 +15727,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano03_T1": {
@@ -14675,6 +15771,10 @@
         "9a395a0d318fd9e8e0f036162af40455"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14719,6 +15819,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano04_A1": {
@@ -14759,6 +15863,10 @@
         "cf99530f85dfdb2f12b546b8992847c4"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14803,6 +15911,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano04_B1": {
@@ -14843,6 +15955,10 @@
         "15e337f77075e4e8c39fbce6b245820d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14887,6 +16003,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano04_S1": {
@@ -14927,6 +16047,10 @@
         "3042063e4dcaa8fe6081050f2df8b556"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -14971,6 +16095,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_ScaleUpDownPiano04_T1": {
@@ -15011,6 +16139,10 @@
         "c968a69cebb33f44109eaef393b1c361"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15055,6 +16187,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning01_A1": {
@@ -15095,6 +16231,10 @@
         "d27c5b872565514fe216ab17f82c3dad"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15139,6 +16279,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning01_B1": {
@@ -15179,6 +16323,10 @@
         "3f8e99d7a57d410193b789a195f9809d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15223,6 +16371,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning01_S1": {
@@ -15263,6 +16415,10 @@
         "8c37eaedced1b27ca4197facaf6305e4"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15307,6 +16463,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning01_T1": {
@@ -15347,6 +16507,10 @@
         "cb50457b6505425a07948d80e90d77ec"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15391,6 +16555,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning02_A1": {
@@ -15431,6 +16599,10 @@
         "988cfe3506e7c9514acb2a1bda07ca1e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15475,6 +16647,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning02_B1": {
@@ -15515,6 +16691,10 @@
         "d4ce1161ed2bd7262eed50cd79c509bb"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15559,6 +16739,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning02_S1": {
@@ -15599,6 +16783,10 @@
         "235688d5f3cb4c1d07f31f2ecdea4d85"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15643,6 +16831,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning02_T1": {
@@ -15683,6 +16875,10 @@
         "45951f90f93acd80c90a2344117cfe71"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15727,6 +16923,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning03_A1": {
@@ -15767,6 +16967,10 @@
         "50570d2c787afa44f1fd14068cb06945"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15811,6 +17015,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning03_B1": {
@@ -15851,6 +17059,10 @@
         "1b1f5b3b1dbba6009422b0f0fc09f3c2"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15895,6 +17107,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning03_S1": {
@@ -15935,6 +17151,10 @@
         "92205abecf54daca2cb946726d80b26e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -15979,6 +17199,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning03_T1": {
@@ -16019,6 +17243,10 @@
         "d7cc5709894bf0961a86052a0b17a605"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16063,6 +17291,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning04_A1": {
@@ -16103,6 +17335,10 @@
         "6cbc7631925d1197835d26eda282f706"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16147,6 +17383,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning04_B1": {
@@ -16187,6 +17427,10 @@
         "6ae14453c77c5accd5297b3f0ab648a0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16231,6 +17475,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning04_S1": {
@@ -16271,6 +17519,10 @@
         "cbb91264d4f93792213bcba54f3ee670"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16315,6 +17567,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Tuning04_T1": {
@@ -16355,6 +17611,10 @@
         "592d2efcbf08460b51ed767a9f9a8bc7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16399,6 +17659,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Unison01_A1": {
@@ -16439,6 +17703,10 @@
         "3f5c4d04b1df40f08d586dd72da45f6a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16483,6 +17751,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Unison01_B1": {
@@ -16523,6 +17795,10 @@
         "8f6c35c86e8bb40ec411161865ba23f0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16567,6 +17843,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Unison01_S1": {
@@ -16607,6 +17887,10 @@
         "8e329282cd5c6fa4d6c5cd1cdcaa4f49"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16651,6 +17935,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_FullChoir_Unison01_T1": {
@@ -16691,6 +17979,10 @@
         "856ecc08f32a871ec0213176493869ff"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16735,6 +18027,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor01_A1": {
@@ -16775,6 +18071,10 @@
         "ca789789742ea3440717775d773441e0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16819,6 +18119,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor01_S2": {
@@ -16859,6 +18163,10 @@
         "a67bf81acf86978f9e2b4aa8410d8cad"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16903,6 +18211,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor02_A1": {
@@ -16943,6 +18255,10 @@
         "566316b44b85ea03e9de130b9d91a48b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -16987,6 +18303,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor02_S2": {
@@ -17027,6 +18347,10 @@
         "389f8de189d555234685453119963c80"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17071,6 +18395,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor03_A1": {
@@ -17111,6 +18439,10 @@
         "9bc00559fd4c693b2c3ec70c39d5768f"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17155,6 +18487,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor03_S2": {
@@ -17195,6 +18531,10 @@
         "c53eab1b00a017d25f0ec72df27b781a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17239,6 +18579,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor04_A1": {
@@ -17279,6 +18623,10 @@
         "d360e8e444ad406cc23220c25efd28ec"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17323,6 +18671,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor04_S2": {
@@ -17363,6 +18715,10 @@
         "b7278624ee56ccfdeb8eb5c2d7ed34ec"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17407,6 +18763,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor05_A1": {
@@ -17447,6 +18807,10 @@
         "df9baf01be144b5d09840a53b7426b0d"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17491,6 +18855,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajor05_S2": {
@@ -17531,6 +18899,10 @@
         "4ee25994a59754200e3263b912b44c74"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17575,6 +18947,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano01_A1": {
@@ -17615,6 +18991,10 @@
         "9148e7586693bb64eac05352923b2fa7"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17659,6 +19039,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano01_S2": {
@@ -17699,6 +19083,10 @@
         "6a07fe9213304ee7c837c46d2aee1d7e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17743,6 +19131,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano02_A1": {
@@ -17783,6 +19175,10 @@
         "d17fbf265aa5a6f6c39ce8cbb5556350"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17827,6 +19223,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano02_S2": {
@@ -17867,6 +19267,10 @@
         "0822c2d50a57c2f67c56425dec3bb521"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17911,6 +19315,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano03_A1": {
@@ -17951,6 +19359,10 @@
         "bfa4d1888e583bf7de7626a745dd5909"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -17995,6 +19407,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano03_S2": {
@@ -18035,6 +19451,10 @@
         "a75cf2f7fcf706818681d6757d21e64e"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18079,6 +19499,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano04_A1": {
@@ -18119,6 +19543,10 @@
         "1d752de0497b155a959503a1fc6cfd79"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18163,6 +19591,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano04_S2": {
@@ -18203,6 +19635,10 @@
         "982081e1e08587790d0089e12a498054"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18247,6 +19683,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano05_A1": {
@@ -18287,6 +19727,10 @@
         "54fe6221c1a979ea9bb9ec5b0ff34d09"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18331,6 +19775,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMajorPiano05_S2": {
@@ -18371,6 +19819,10 @@
         "ac0fbd64ff3dc24507137650d975cfd9"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18415,6 +19867,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinor01_A1": {
@@ -18455,6 +19911,10 @@
         "16e7ea72eaf7aff3d0b28feb72d08355"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18499,6 +19959,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinor01_S2": {
@@ -18539,6 +20003,10 @@
         "f5111e86eda00d7bf2cc795921c9417b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18583,6 +20051,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinor02_A1": {
@@ -18623,6 +20095,10 @@
         "ae7f4b62b832cb83956f05d01a60ba58"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18667,6 +20143,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinor02_S2": {
@@ -18707,6 +20187,10 @@
         "c998a1ee43f554c84fb48383d32853a5"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18751,6 +20235,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano01_A1": {
@@ -18791,6 +20279,10 @@
         "a65579e9d5d8420f3d19bba75497ae1b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18835,6 +20327,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano01_S2": {
@@ -18875,6 +20371,10 @@
         "65492b8ead643c5b449be2cfe8d3f591"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -18919,6 +20419,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano02_A1": {
@@ -18959,6 +20463,10 @@
         "8dca4f7c3a19861828f5856483897d38"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19003,6 +20511,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano02_S2": {
@@ -19043,6 +20555,10 @@
         "a6dd14bf600296b943d5e9697c9e35c0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19087,6 +20603,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano03_A1": {
@@ -19127,6 +20647,10 @@
         "74ec30ce83ba6ea06bd45dc4bdb74df3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19171,6 +20695,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_CadenceMinorPiano03_S2": {
@@ -19211,6 +20739,10 @@
         "a08033257f5ed7203f0dc1225fd83532"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19255,6 +20787,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano01_A1": {
@@ -19295,6 +20831,10 @@
         "dba46d4f8f7c471acbeaa0c2c95b6180"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19339,6 +20879,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano01_S2": {
@@ -19379,6 +20923,10 @@
         "69b5d9c45453f4e841a27f9acdeec80c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19423,6 +20971,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano02_A1": {
@@ -19463,6 +21015,10 @@
         "f5b0b2e29e89063275c5f9380cb730f1"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19507,6 +21063,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano02_S2": {
@@ -19547,6 +21107,10 @@
         "1bd3229be78c18577692fed636a2fc80"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19591,6 +21155,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano03_A1": {
@@ -19631,6 +21199,10 @@
         "ed627f4298af732540f8797cdfeca1ba"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19675,6 +21247,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano03_S2": {
@@ -19715,6 +21291,10 @@
         "f7df6a195a87e269130cd07e18abf289"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19759,6 +21339,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano04_A1": {
@@ -19799,6 +21383,10 @@
         "96dc4277f0d34f7e34953b68c28d12db"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19843,6 +21431,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano04_S2": {
@@ -19883,6 +21475,10 @@
         "2d6be324e4078270494e8499bbd4ffd6"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -19927,6 +21523,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano05_A1": {
@@ -19967,6 +21567,10 @@
         "c857102682e6dbee224188bec8859722"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20011,6 +21615,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano05_S2": {
@@ -20051,6 +21659,10 @@
         "1711466be2a9fdcd7cdc0195c7e7f7eb"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20095,6 +21707,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano06_A1": {
@@ -20135,6 +21751,10 @@
         "e11d66ab85e9af56b0b5023b58d56649"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20179,6 +21799,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano06_S2": {
@@ -20219,6 +21843,10 @@
         "8c27c6b52def0eba4caa71f66c48124c"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20263,6 +21891,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano07_A1": {
@@ -20303,6 +21935,10 @@
         "2c5f482b3440ec8e581f451593651d41"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20347,6 +21983,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano07_S2": {
@@ -20387,6 +22027,10 @@
         "79ab80b1660c486187117f3c3fc88ed3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20431,6 +22075,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano08_A1": {
@@ -20471,6 +22119,10 @@
         "a0f72f5b502158eda6e35c999ff8ff6a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20515,6 +22167,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_HummingPiano08_S2": {
@@ -20555,6 +22211,10 @@
         "ba75d069c08b194f1dd7c56c4e37dd21"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20599,6 +22259,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_Tuning01_A1": {
@@ -20639,6 +22303,10 @@
         "df03a596a3f442efc7f5c8c1f1108da1"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20683,6 +22351,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_Tuning01_S2": {
@@ -20723,6 +22395,10 @@
         "8a7dc0d6a5108bf726e33554588f71a3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20767,6 +22443,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_Tuning02_A1": {
@@ -20807,6 +22487,10 @@
         "70c922cef16baafc3a2aa58e83ac29f3"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20851,6 +22535,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetA_Tuning02_S2": {
@@ -20891,6 +22579,10 @@
         "16bf63f9c70cabf1b32808e087a8f77b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -20935,6 +22627,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetB_Tuning01_A2": {
@@ -20975,6 +22671,10 @@
         "0a0a6659dcee5ff40a236933f9398c9b"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21019,6 +22719,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetB_Tuning01_S1": {
@@ -21059,6 +22763,10 @@
         "90e858f6616471be0e20a67f6ab09810"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21103,6 +22811,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetB_Tuning02_A2": {
@@ -21143,6 +22855,10 @@
         "eceaaf34cd627b82ea2eda9e9ce68475"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21187,6 +22903,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_SE_QuartetB_Tuning02_S1": {
@@ -21227,6 +22947,10 @@
         "06705305e3ec41e5f9bddb25d3166562"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21271,6 +22995,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_TP_FullChoir_Outtake_A1": {
@@ -21311,6 +23039,10 @@
         "fea4b60d0d7f71cd17cd648278bcde0a"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21355,6 +23087,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_TP_FullChoir_Outtake_B1": {
@@ -21395,6 +23131,10 @@
         "182b5ac6c52d4ac31f81dba8a584cda0"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21439,6 +23179,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_TP_FullChoir_Outtake_S1": {
@@ -21479,6 +23223,10 @@
         "acc6d7c492679b98135df832b30700cd"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]
@@ -21523,6 +23271,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_TP_FullChoir_Outtake_T1": {
@@ -21565,6 +23317,10 @@
       "f0_manual_lrx": [
         null,
         null
+      ],
+      "score": [
+        null,
+        null
       ]
     },
     "DCS_TP_FullChoir_Outtake_T2": {
@@ -21605,6 +23361,10 @@
         "0d214315f18b1fa82f186da46af20b34"
       ],
       "f0_manual_lrx": [
+        null,
+        null
+      ],
+      "score": [
         null,
         null
       ]

--- a/scripts/make_dagstuhl_choirset_index.py
+++ b/scripts/make_dagstuhl_choirset_index.py
@@ -6,23 +6,25 @@ import os
 
 DATASET_INDEX_PATH = "../mirdata/datasets/indexes/dagstuhl_choirset_index.json"
 
-NO_SCORE = [
-    "Basses", "Overacted", "SE", "Solo", "Outtake"
-]
+NO_SCORE = ["Basses", "Overacted", "SE", "Solo", "Outtake"]
 
 
 def make_dataset_index(data_path):
-    audio_dir = os.path.join(data_path, 'audio_wav_22050_mono')
+    audio_dir = os.path.join(data_path, "audio_wav_22050_mono")
 
-    index = {
-        'version': "1.2.3",
-        "tracks": {},
-        "multitracks": {}
-    }
+    index = {"version": "1.2.3", "tracks": {}, "multitracks": {}}
 
     # define pieces directly from data directory
-    pieces = sorted(list(set(["_".join(filename.split('/')[-1].split('_')[:4]) for filename in
-                              glob.glob(os.path.join(audio_dir, '*.wav'))])))
+    pieces = sorted(
+        list(
+            set(
+                [
+                    "_".join(filename.split("/")[-1].split("_")[:4])
+                    for filename in glob.glob(os.path.join(audio_dir, "*.wav"))
+                ]
+            )
+        )
+    )
 
     for ip, piece in enumerate(pieces):
 
@@ -37,7 +39,7 @@ def make_dataset_index(data_path):
         audio_checksum = md5(audio_mix_dir)
         index["multitracks"][piece]["audio_stm"] = (
             "audio_wav_22050_mono/{}_Stereo_STM.wav".format(piece),
-            audio_checksum
+            audio_checksum,
         )
 
         # STR
@@ -47,7 +49,7 @@ def make_dataset_index(data_path):
         audio_checksum = md5(audio_mix_dir)
         index["multitracks"][piece]["audio_str"] = (
             "audio_wav_22050_mono/{}_Stereo_STR.wav".format(piece),
-            audio_checksum
+            audio_checksum,
         )
 
         # STL
@@ -57,7 +59,7 @@ def make_dataset_index(data_path):
         audio_checksum = md5(audio_mix_dir)
         index["multitracks"][piece]["audio_stl"] = (
             "audio_wav_22050_mono/{}_Stereo_STL.wav".format(piece),
-            audio_checksum
+            audio_checksum,
         )
 
         # STRev
@@ -67,7 +69,7 @@ def make_dataset_index(data_path):
         audio_checksum = md5(audio_mix_dir)
         index["multitracks"][piece]["audio_rev"] = (
             "audio_wav_22050_mono/{}_StereoReverb_STM.wav".format(piece),
-            audio_checksum
+            audio_checksum,
         )
 
         # beats
@@ -80,10 +82,12 @@ def make_dataset_index(data_path):
         ## add each track inside the multitrack
 
         audio_files = sorted(
-            glob.glob(os.path.join(audio_dir, '{}*.wav'.format(piece)))
+            glob.glob(os.path.join(audio_dir, "{}*.wav".format(piece)))
         )
 
-        singers = [singer.split('_')[-2] for singer in audio_files if not "Stereo" in singer]
+        singers = [
+            singer.split("_")[-2] for singer in audio_files if not "Stereo" in singer
+        ]
 
         # second step to remove piano from singers
         singers = [singer for singer in singers if "Piano" not in singer]
@@ -99,18 +103,29 @@ def make_dataset_index(data_path):
             track_name = "{}_{}".format(piece, singer)
 
             # define fields as None
-            index['tracks'][track_name] = {
-                "audio_dyn": (None, None), "audio_hsm": (None, None), "audio_lrx": (None, None),
-                "f0_crepe_dyn": (None, None), "f0_crepe_hsm": (None, None), "f0_crepe_lrx": (None, None),
-                "f0_pyin_dyn": (None, None), "f0_pyin_hsm": (None, None), "f0_pyin_lrx": (None, None),
-                "f0_manual_lrx": (None, None)
+            index["tracks"][track_name] = {
+                "audio_dyn": (None, None),
+                "audio_hsm": (None, None),
+                "audio_lrx": (None, None),
+                "f0_crepe_dyn": (None, None),
+                "f0_crepe_hsm": (None, None),
+                "f0_crepe_lrx": (None, None),
+                "f0_pyin_dyn": (None, None),
+                "f0_pyin_hsm": (None, None),
+                "f0_pyin_lrx": (None, None),
+                "f0_manual_lrx": (None, None),
+                "score": (None, None),
             }
 
-            index['multitracks'][piece]['tracks'].append(track_name)
+            index["multitracks"][piece]["tracks"].append(track_name)
 
-            mics = [mic.split('_')[-1].split('.')[0] for mic in glob.glob(os.path.join(
-                audio_dir, "{}_{}*.wav".format(piece, singer))
-            ) if mic not in ['SPL', 'SPR']]
+            mics = [
+                mic.split("_")[-1].split(".")[0]
+                for mic in glob.glob(
+                    os.path.join(audio_dir, "{}_{}*.wav".format(piece, singer))
+                )
+                if mic not in ["SPL", "SPR"]
+            ]
 
             ### add all fields for each track
 
@@ -118,35 +133,41 @@ def make_dataset_index(data_path):
 
                 ## add audio
                 audio_stem_dir = os.path.join(
-                    data_path, "audio_wav_22050_mono", "{}_{}_{}.wav".format(piece, singer, mic)
+                    data_path,
+                    "audio_wav_22050_mono",
+                    "{}_{}_{}.wav".format(piece, singer, mic),
                 )
                 audio_checksum = md5(audio_stem_dir)
 
                 index["tracks"][track_name]["audio_{}".format(mic.lower())] = (
                     "audio_wav_22050_mono/{}_{}_{}.wav".format(piece, singer, mic),
-                    audio_checksum
+                    audio_checksum,
                 )
 
                 ## add crepe f0s
                 crepe_dir = os.path.join(
-                    data_path, "annotations_csv_F0_CREPE", "{}_{}_{}.csv".format(piece, singer, mic)
+                    data_path,
+                    "annotations_csv_F0_CREPE",
+                    "{}_{}_{}.csv".format(piece, singer, mic),
                 )
                 crepe_checksum = md5(crepe_dir)
 
-                index['tracks'][track_name]["f0_crepe_{}".format(mic.lower())] = (
+                index["tracks"][track_name]["f0_crepe_{}".format(mic.lower())] = (
                     "annotations_csv_F0_CREPE/{}_{}_{}.csv".format(piece, singer, mic),
-                    crepe_checksum
+                    crepe_checksum,
                 )
 
                 ## add pyin f0s
                 pyin_dir = os.path.join(
-                    data_path, "annotations_csv_F0_PYIN", "{}_{}_{}.csv".format(piece, singer, mic)
+                    data_path,
+                    "annotations_csv_F0_PYIN",
+                    "{}_{}_{}.csv".format(piece, singer, mic),
                 )
                 pyin_checksum = md5(pyin_dir)
 
                 index["tracks"][track_name]["f0_pyin_{}".format(mic.lower())] = (
                     "annotations_csv_F0_PYIN/{}_{}_{}.csv".format(piece, singer, mic),
-                    pyin_checksum
+                    pyin_checksum,
                 )
 
                 ## add score when it exists
@@ -154,14 +175,17 @@ def make_dataset_index(data_path):
                 # some have no associated score
                 if not any(x in piece for x in NO_SCORE):
                     score_dir = os.path.join(
-                        data_path, "annotations_csv_scorerepresentation",
-                        "{}_Stereo_STM_{}.csv".format(piece, singer[0])
+                        data_path,
+                        "annotations_csv_scorerepresentation",
+                        "{}_Stereo_STM_{}.csv".format(piece, singer[0]),
                     )
                     score_checksum = md5(score_dir)
 
                     index["tracks"][track_name]["score"] = (
-                        "annotations_csv_scorerepresentation/{}_Stereo_STM_{}.csv".format(piece, singer[0]),
-                        score_checksum
+                        "annotations_csv_scorerepresentation/{}_Stereo_STM_{}.csv".format(
+                            piece, singer[0]
+                        ),
+                        score_checksum,
                     )
 
             ## add beats for the full songs when available
@@ -175,7 +199,7 @@ def make_dataset_index(data_path):
 
                 index["multitracks"][piece]["beat"] = (
                     "annotations_csv_beat/{}_Stereo_STM.csv".format(piece),
-                    beats_checksum
+                    beats_checksum,
                 )
 
         ## check if piano track exists and add it to the mtrack if so
@@ -188,36 +212,36 @@ def make_dataset_index(data_path):
             audio_checksum = md5(audio_pianoL_dir)
             index["multitracks"][piece]["audio_spl"] = (
                 "audio_wav_22050_mono/{}_Piano_SPL.wav".format(piece),
-                audio_checksum
+                audio_checksum,
             )
 
             # add piano SPR
             audio_checksum = md5(audio_pianoL_dir.replace("SPL", "SPR"))
             index["multitracks"][piece]["audio_spr"] = (
                 "audio_wav_22050_mono/{}_Piano_SPR.wav".format(piece),
-                audio_checksum
+                audio_checksum,
             )
 
         # tracks should not be repeated
-        index['multitracks'][piece]['tracks'] = sorted(list(set(index['multitracks'][piece]['tracks'])))
+        index["multitracks"][piece]["tracks"] = sorted(
+            list(set(index["multitracks"][piece]["tracks"]))
+        )
 
     ## add the manual annotations to their corresponding tracks
     manual_files = sorted(
-        glob.glob(os.path.join(
-            data_path, "annotations_csv_F0_manual", "*.csv")
-        )
+        glob.glob(os.path.join(data_path, "annotations_csv_F0_manual", "*.csv"))
     )
     for mf in manual_files:
-        track_name = "_".join(os.path.basename(mf).split('_')[:-1])
+        track_name = "_".join(os.path.basename(mf).split("_")[:-1])
 
         manual_checksum = md5(mf)
 
         index["tracks"][track_name]["f0_manual_lrx"] = (
             "annotations_csv_F0_manual/{}".format(os.path.basename(mf)),
-            manual_checksum
+            manual_checksum,
         )
 
-    with open(DATASET_INDEX_PATH, 'w') as fhandle:
+    with open(DATASET_INDEX_PATH, "w") as fhandle:
         json.dump(index, fhandle, indent=2)
 
 
@@ -226,10 +250,10 @@ def main(args):
 
 
 #
-if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(description='Make Dagstuhl ChoirSet index file.')
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser(description="Make Dagstuhl ChoirSet index file.")
     PARSER.add_argument(
-        'data_path', type=str, help='Path to Dagstuhl ChoirSet data folder.'
+        "data_path", type=str, help="Path to Dagstuhl ChoirSet data folder."
     )
 
     main(PARSER.parse_args())

--- a/tests/test_dagstuhl_choirset.py
+++ b/tests/test_dagstuhl_choirset.py
@@ -14,29 +14,31 @@ def test_track():
 
     expected_attributes = {
         "track_id": "DCS_LI_QuartetB_Take04_B2",
-        "audio_paths": [
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_DYN.wav",
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_HSM.wav",
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_LRX.wav",
-        ],
-        "f0_paths": [
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_DYN.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_HSM.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_LRX.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_DYN.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_HSM.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_LRX.csv",
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_manual/DCS_LI_QuartetB_Take04_B2_LRX.csv",
-        ],
-        "score_paths": [
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_scorerepresentation/DCS_LI_QuartetB_Take04_Stereo_STM_B.csv"
-        ],
+        "audio_dyn_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_DYN.wav",
+        "audio_hsm_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_HSM.wav",
+        "audio_lrx_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_B2_LRX.wav",
+        "f0_crepe_dyn_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_DYN.csv",
+        "f0_crepe_hsm_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_HSM.csv",
+        "f0_crepe_lrx_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_LRX.csv",
+        "f0_pyin_dyn_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_DYN.csv",
+        "f0_pyin_hsm_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_HSM.csv",
+        "f0_pyin_lrx_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_PYIN/DCS_LI_QuartetB_Take04_B2_LRX.csv",
+        "f0_manual_lrx_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_manual/DCS_LI_QuartetB_Take04_B2_LRX.csv",
+        "score_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_scorerepresentation/DCS_LI_QuartetB_Take04_Stereo_STM_B.csv",
     }
 
     expected_property_types = {
-        "f0": annotations.F0Data,
+        "f0_crepe_dyn": annotations.F0Data,
+        "f0_crepe_hsm": annotations.F0Data,
+        "f0_crepe_lrx": annotations.F0Data,
+        "f0_pyin_dyn": annotations.F0Data,
+        "f0_pyin_hsm": annotations.F0Data,
+        "f0_pyin_lrx": annotations.F0Data,
+        "f0_manual_lrx": annotations.F0Data,
         "score": annotations.NoteData,
-        "audio": tuple,
+        "audio_dyn": tuple,
+        "audio_hsm": tuple,
+        "audio_lrx": tuple,
     }
 
     run_track_tests(track, expected_attributes, expected_property_types)
@@ -48,48 +50,119 @@ def test_audio_track():
     dataset = dagstuhl_choirset.Dataset(data_home)
     track = dataset.track(default_trackid)
 
-    y, sr = track.audio()
+    y, sr = track.audio_dyn
     assert sr == 22050
     assert y.shape == (22050,)
 
-    y, sr = track.audio("LRX")
+    y, sr = track.audio_lrx
     assert sr == 22050
     assert y.shape == (22050,)
 
-    y, sr = track.audio("HSM")
+    y, sr = track.audio_hsm
     assert sr == 22050
     assert y.shape == (22050,)
-
-    y, sr = track.audio("DYN")
-    assert sr == 22050
-    assert y.shape == (22050,)
-
-    with pytest.raises(ValueError):
-        y, sr = track.audio("abc")
 
     default_trackid = "DCS_SE_QuartetB_Tuning02_S1"
     data_home = "tests/resources/mir_datasets/dagstuhl_choirset"
     dataset = dagstuhl_choirset.Dataset(data_home)
     track = dataset.track(default_trackid)
-    assert None == track.audio("hsm")
+    assert track.audio_hsm is None
 
 
-def test_f0_track():
-    default_trackid = "DCS_LI_QuartetB_Take04_B2"
-    data_home = "tests/resources/mir_datasets/dagstuhl_choirset"
-    dataset = dagstuhl_choirset.Dataset(data_home)
-    track = dataset.track(default_trackid)
+def test_load_f0():
+    f0_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_CREPE/DCS_LI_QuartetB_Take04_B2_DYN.csv"
+    f0 = dagstuhl_choirset.load_f0(f0_path)
+    assert isinstance(f0, annotations.F0Data)
 
-    with pytest.raises(ValueError):
-        f0_traj = track.f0(mic="lrxa", ann="crepe")
+    assert np.array_equal(f0.times, np.array([0.0, 0.01, 0.02, 0.03, 0.04]))
+    assert np.array_equal(
+        f0.frequencies,
+        np.array(
+            [
+                204.329447420415,
+                205.1518935649711,
+                205.52465246964104,
+                205.45427855215388,
+                205.51663864023027,
+            ]
+        ),
+    )
+    assert np.array_equal(
+        f0.confidence,
+        np.array(
+            [
+                0.050135254859924316,
+                0.02886691689491272,
+                0.0374043881893158,
+                0.04053276777267456,
+                0.053232729434967034,
+            ]
+        ),
+    )
 
-    with pytest.raises(ValueError):
-        f0_traj = track.f0(mic="lrx", ann="crepae")
+    f0_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_F0_manual/DCS_LI_QuartetB_Take04_B2_LRX.csv"
+    f0 = dagstuhl_choirset.load_f0(f0_path)
+    assert isinstance(f0, annotations.F0Data)
 
-    with pytest.raises(ValueError):
-        f0_traj = track.f0(mic="lrdsx", ann="credfpae")
+    assert np.array_equal(
+        f0.times,
+        np.array([0.400544218, 0.406349206, 0.412154195, 0.417959184, 0.423764172]),
+    )
+    assert np.array_equal(
+        f0.frequencies,
+        np.array(
+            [
+                129.387,
+                126.634,
+                125.182,
+                124.943,
+                124.491,
+            ]
+        ),
+    )
+    assert np.array_equal(f0.confidence, np.array([1, 1, 1, 1, 1]))
 
-    assert None == track.f0(mic="dyn", ann="manual")
+
+def test_load_score():
+
+    score_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_scorerepresentation/DCS_LI_QuartetB_Take04_Stereo_STM_B.csv"
+    score = dagstuhl_choirset.load_score(score_path)
+    assert isinstance(score, annotations.NoteData)
+
+    assert np.array_equal(
+        score.intervals,
+        np.array(
+            [
+                [0.1600, 2.5165],
+                [2.5165, 3.3487],
+                [3.3487, 4.8130],
+                [4.8130, 5.7252],
+                [5.7252, 6.3774],
+            ]
+        ),
+    )
+
+    assert np.allclose(
+        score.notes,
+        np.array(
+            [130.81278265, 130.81278265, 130.81278265, 130.81278265, 130.81278265]
+        ),
+    )
+    assert score.confidence is None
+
+
+def test_load_beat():
+
+    beat_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_beat/DCS_LI_QuartetB_Take04_Stereo_STM.csv"
+    beat = dagstuhl_choirset.load_beat(beat_path)
+    assert isinstance(beat, annotations.BeatData)
+
+    assert np.array_equal(
+        beat.times,
+        np.array([0.174149660, 0.949115646, 1.724081633, 2.525170068, 3.308843537]),
+    )
+
+    assert np.array_equal(beat.positions, np.array([1, 2, 3, 4, 1]))
 
 
 def test_score_track():
@@ -98,7 +171,7 @@ def test_score_track():
     dataset = dagstuhl_choirset.Dataset(data_home)
     track = dataset.track(default_trackid)
 
-    assert None == track.score()
+    assert track.score is None
 
 
 def test_to_jams_track():
@@ -146,21 +219,18 @@ def test_multitrack():
 
     expected_attributes = {
         "mtrack_id": "DCS_LI_QuartetB_Take04",
-        "track_audio_property": "audio",
+        "audio_stm_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STM.wav",
+        "audio_str_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STR.wav",
+        "audio_stl_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STL.wav",
+        "audio_rev_path": "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_StereoReverb_STM.wav",
+        "audio_spl_path": None,
+        "audio_spr_path": None,
+        "beat_path": "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_beat/DCS_LI_QuartetB_Take04_Stereo_STM.csv",
         "track_ids": [
             "DCS_LI_QuartetB_Take04_A2",
             "DCS_LI_QuartetB_Take04_B2",
             "DCS_LI_QuartetB_Take04_S1",
             "DCS_LI_QuartetB_Take04_T2",
-        ],
-        "audio_paths": [
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STM.wav",
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STR.wav",
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_Stereo_STL.wav",
-            "tests/resources/mir_datasets/dagstuhl_choirset/audio_wav_22050_mono/DCS_LI_QuartetB_Take04_StereoReverb_STM.wav",
-        ],
-        "beat_paths": [
-            "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_beat/DCS_LI_QuartetB_Take04_Stereo_STM.csv"
         ],
     }
 
@@ -168,7 +238,12 @@ def test_multitrack():
         "tracks": dict,
         "track_audio_property": str,
         "beat": annotations.BeatData,
-        "audio": tuple,
+        "audio_stm": tuple,
+        "audio_str": tuple,
+        "audio_stl": tuple,
+        "audio_rev": tuple,
+        "audio_spl": type(None),
+        "audio_spr": type(None),
     }
 
     run_track_tests(mtrack, expected_attributes, expected_property_types)
@@ -181,7 +256,7 @@ def test_beat_multitrack():
     dataset = dagstuhl_choirset.Dataset(data_home)
     mtrack = dataset.multitrack(default_trackid)
 
-    assert None == mtrack.beat()
+    assert mtrack.beat is None
 
 
 def test_audio_multitrack():
@@ -190,26 +265,23 @@ def test_audio_multitrack():
     dataset = dagstuhl_choirset.Dataset(data_home)
     mtrack = dataset.multitrack(default_trackid)
 
-    y, sr = mtrack.audio("STM")
+    y, sr = mtrack.audio_stm
     assert sr == 22050
     assert y.shape == (22050,)
 
-    y, sr = mtrack.audio("stereoreverb_stm")
+    y, sr = mtrack.audio_rev
     assert sr == 22050
     assert y.shape == (22050,)
 
-    y, sr = mtrack.audio("STL")
+    y, sr = mtrack.audio_stl
     assert sr == 22050
     assert y.shape == (22050,)
 
-    y, sr = mtrack.audio("STR")
+    y, sr = mtrack.audio_str
     assert sr == 22050
     assert y.shape == (22050,)
 
-    assert None == mtrack.audio("spl")
-
-    with pytest.raises(ValueError):
-        y, sr = mtrack.audio("abc")
+    assert mtrack.audio_spl is None
 
 
 def test_to_jams_multitrack():
@@ -229,4 +301,4 @@ def test_to_jams_multitrack():
         2.525170068,
         3.308843537,
     ]
-    assert [beat.value for beat in beats] == [1, 2, 3, 4, 5]
+    assert [beat.value for beat in beats] == [1, 2, 3, 4, 1]


### PR DESCRIPTION
* breaks the attribute lists into individual explicit attributes
* updates tests
* adds tests for each loader specifically
* updates some details (e.g. uses cached_property & property)
* fixes a bug in the index creation (score data is now none by default)
* fixed a bug in the beat data loading (position data should repeat every measure)